### PR TITLE
fix: `MessageService`  doc typo

### DIFF
--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -1425,7 +1425,7 @@
                         }
                     ],
                     "returnType": "void",
-                    "description": "Insterts new messages."
+                    "description": "Inserts new messages."
                 },
                 {
                     "name": "clear",


### PR DESCRIPTION
This PR fixes the typo in `MessageService` doc